### PR TITLE
rename the Arch Linux package to dysk

### DIFF
--- a/website/docs/install.md
+++ b/website/docs/install.md
@@ -64,12 +64,10 @@ Those packages are maintained by third parties and may be less up to date.
 
 ## Arch Linux
 
-(with its previous name, "lfs")
-
-**dysk** can be installed from the [community repository](https://archlinux.org/packages/community/x86_64/lfs/):
+**dysk** can be installed from the [extra repository](https://archlinux.org/packages/extra/x86_64/dysk/):
 
 ```
-pacman -S lfs
+pacman -S dysk
 ```
 
 


### PR DESCRIPTION
See <https://archlinux.org/packages/extra/x86_64/dysk/>

> replaces: lfs
