### PR TITLE
Fix broken link to `lfs-core` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,6 @@ You can output the table as CSV too.
 
 ### Library
 
-The data displayed by dysk is provided by the [lfs-core](github.com/Canop/lfs-core) crate.
+The data displayed by dysk is provided by the [lfs-core](https://github.com/Canop/lfs-core) crate.
 You may use it in your own Rust application.
 


### PR DESCRIPTION
The current link is interpreted as relative and therefore points to https://github.com/Canop/dysk/blob/main/github.com/Canop/lfs-core