### PR TITLE
Use base-2 logs to retrieve binary prefixes

### DIFF
--- a/cli/src/units.rs
+++ b/cli/src/units.rs
@@ -37,9 +37,9 @@ impl Units {
                 if size < 10_000 {
                     size.to_string()
                 } else {
-                    let size = size as f64;
-                    let i: u32 = (size.ln() / 1024f64.ln()) as u32;
+                    let i = size.ilog2() / 10u32;
                     let idx = i as usize - 1;
+                    let size = size as f64;
                     if idx >= PREFIXES.len() {
                         "huge".to_string()
                     } else {


### PR DESCRIPTION
Hello,

While completing the packaging for Debian, `disk-cli`'s test `units::test_fmt_binary` failed on i386 because `1_073_741_824` was formatted as `1024Mi` instead of `1Gi`. I traced this down to the sequence casting to `f64` + log + division + recasting to `u32`, which introduces errors (a 2.99999 most probably got rounded down to 2) because [floats are non-compliant on 32-bit x86 with SSE2 disabled](https://github.com/rust-lang/rust/issues/114479), which is the target in use by Debian for i386.

I was able to fix this by avoiding casting to floats: since ln(size) / ln(1024) = log_2(size) / log_2(1024) = log_2(size) / 10, I could use `ilog2`, which is defined on `u64`s and returns `u32`s, thus avoiding two casts and one log. This change passes all tests on all archs supported by Debian, as you can see [here](https://buildd.debian.org/status/package.php?p=rust-dysk-cli) (builds include testing). I am therefore submitting it hoping you'll find it useful.