### PR TITLE
Mac: list mounts not backed by a local phys device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -469,8 +469,9 @@ dependencies = [
 
 [[package]]
 name = "lfs-core"
-version = "0.16.2"
-source = "git+https://github.com/Canop/lfs-core.git?branch=smb#76e696971b187d389966c9dc75889bf16655ca88"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0745105cde4e8b166b96a9e6db9de41c8694540fb787018607297b9d9ff6fd0"
 dependencies = [
  "core-foundation",
  "core-foundation-sys",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,9 +14,9 @@ bet = "1.0.4"
 clap = { version = "4.4", features = ["derive", "cargo"] }
 clap-help = "1.4"
 file-size = "1.0.3"
-lfs-core = { git = "https://github.com/Canop/lfs-core.git", branch = "smb" }
+#lfs-core = { git = "https://github.com/Canop/lfs-core.git", branch = "smb" }
 #lfs-core = { path = "../../lfs-core" }
-#lfs-core = "0.16.2"
+lfs-core = "0.17.0"
 serde = "1.0"
 serde_json = "1.0"
 termimad = "0.34"


### PR DESCRIPTION
Fix #101 (at least partially, doesn't work for AFP shares)