### PR TITLE
silently handle broken pipe on printing to stdout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
  "lfs-core",
  "serde",
  "serde_json",
- "termimad 0.34.0",
+ "termimad 0.34.1",
 ]
 
 [[package]]
@@ -536,6 +536,15 @@ name = "minimad"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9c5d708226d186590a7b6d4a9780e2bdda5f689e0d58cd17012a298efd745d2"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "minimad"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df8b688969b16915f3ecadc7829d5b7779dee4977e503f767f34136803d5c06f"
 dependencies = [
  "once_cell",
 ]
@@ -829,7 +838,7 @@ dependencies = [
  "crokey",
  "crossbeam",
  "lazy-regex",
- "minimad",
+ "minimad 0.13.1",
  "serde",
  "thiserror 2.0.15",
  "unicode-width",
@@ -837,15 +846,15 @@ dependencies = [
 
 [[package]]
 name = "termimad"
-version = "0.34.0"
+version = "0.34.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ff5ca043d65d4ea43b65cdb4e3aba119657d0d12caf44f93212ec3168a8e20"
+checksum = "889a9370996b74cf46016ce35b96c248a9ac36d69aab1d112b3e09bc33affa49"
 dependencies = [
  "coolor",
  "crokey",
  "crossbeam",
  "lazy-regex",
- "minimad",
+ "minimad 0.14.0",
  "serde",
  "thiserror 2.0.15",
  "unicode-width",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,11 +19,9 @@ file-size = "1.0.3"
 lfs-core = "0.18.0"
 serde = "1.0"
 serde_json = "1.0"
-termimad = "0.34"
+termimad = "0.34.1"
+#termimad = { path = "../../termimad" }
 
 [profile.release]
 strip = true
-
-[patch.crates-io]
-# termimad = { path = "../../termimad" }
 

--- a/cli/src/csv.rs
+++ b/cli/src/csv.rs
@@ -59,12 +59,13 @@ impl<W: Write> Csv<W> {
     }
 }
 
-pub fn print(
+pub fn write<W: Write>(
+    w: &mut W,
     mounts: &[&Mount],
     args: &Args,
-) -> Result<(), std::io::Error> {
+) -> std::io::Result<()> {
     let units = args.units;
-    let mut csv = Csv::new(args.csv_separator, std::io::stdout());
+    let mut csv = Csv::new(args.csv_separator, w);
     for col in args.cols.cols() {
         csv.cell(col.title())?;
     }

--- a/cli/src/list_cols.rs
+++ b/cli/src/list_cols.rs
@@ -4,6 +4,10 @@ use {
         MadSkin,
         minimad::OwningTemplateExpander,
     },
+    std::io::{
+        self,
+        Write,
+    },
 };
 
 static MD: &str = r#"
@@ -25,10 +29,11 @@ ${column
 "#;
 
 /// Print an help text describing columns
-pub fn print(
+pub fn write<W: Write>(
+    w: &mut W,
     color: bool,
     ascii: bool,
-) {
+) -> io::Result<()> {
     let mut expander = OwningTemplateExpander::new();
     expander.set_default("");
     for &col in ALL_COLS {
@@ -47,5 +52,5 @@ pub fn print(
     if ascii {
         skin.limit_to_ascii();
     }
-    skin.print_owning_expander_md(&expander, MD);
+    skin.write_owning_expander_md(w, &expander, MD)
 }

--- a/cli/src/table.rs
+++ b/cli/src/table.rs
@@ -4,6 +4,7 @@ use {
         col::Col,
     },
     lfs_core::*,
+    std::io::Write,
     termimad::{
         CompoundStyle,
         MadSkin,
@@ -27,13 +28,14 @@ static SIZE_COLOR: u8 = 172;
 static BAR_WIDTH: usize = 5;
 static INODES_BAR_WIDTH: usize = 5;
 
-pub fn print(
+pub fn write<W: Write>(
+    w: &mut W,
     mounts: &[&Mount],
     color: bool,
     args: &Args,
-) {
+) -> std::io::Result<()> {
     if args.cols.is_empty() {
-        return;
+        return Ok(());
     }
     let units = args.units;
     let mut expander = OwningTemplateExpander::new();
@@ -136,7 +138,7 @@ pub fn print(
         );
     }
 
-    skin.print_owning_expander_md(&expander, &tbl);
+    skin.write_owning_expander_md(w, &expander, &tbl)
 }
 
 fn make_colored_skin() -> MadSkin {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,6 @@
 #[allow(clippy::match_like_matches_macro)]
 fn main() {
-    dysk_cli::run();
+    if dysk_cli::run().is_err() {
+        std::process::exit(141);
+    }
 }


### PR DESCRIPTION
Fix #104

Also don't print a TTY Reset when called with `--color no` or piped to a non TTY stream

Fix #105