### PR TITLE
docs: Add conda-forge install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dysk
 
-[![CI][s3]][l3] [![MIT][s2]][l2] [![Latest Version][s1]][l1] [![Chat on Miaou][s4]][l4] [![Packaging status][srep]][lrep]
+[![CI][s3]][l3] [![MIT][s2]][l2] [![Latest Version][s1]][l1] [![Conda Version][s5]][l5] [![Chat on Miaou][s4]][l4] [![Packaging status][srep]][lrep]
 
 [s1]: https://img.shields.io/crates/v/dysk.svg
 [l1]: https://crates.io/crates/dysk
@@ -13,6 +13,9 @@
 
 [s4]: https://miaou.dystroy.org/static/shields/room.svg
 [l4]: https://miaou.dystroy.org/4847?dysk
+
+[s5]: https://img.shields.io/conda/vn/conda-forge/dysk.svg
+[l5]: https://anaconda.org/conda-forge/dysk
 
 [srep]: https://repology.org/badge/tiny-repos/dysk.svg
 [lrep]: https://repology.org/project/dysk/versions

--- a/website/src/install.md
+++ b/website/src/install.md
@@ -31,6 +31,24 @@ You may download previous releases on [GitHub releases](https://github.com/Canop
 
 When you download executable files, you'll have to ensure the shell can find them. An easy solution on linux is for example to put them in `/usr/local/bin`. You may also have to set them executable using `chmod +x dysk`.
 
+## From conda-forge
+
+dysk is available as a conda package [on conda-forge](https://github.com/conda-forge/dysk-feedstock) for the following platforms
+
+[![Conda Platforms](https://img.shields.io/conda/pn/conda-forge/dysk.svg)](https://anaconda.org/conda-forge/dysk)
+
+and can be installed globally with [Pixi](https://pixi.sh/):
+
+    pixi global install dysk
+
+or into a particular project with Pixi:
+
+    pixi add dysk
+
+or with [conda](https://docs.conda.io/projects/conda/):
+
+    conda install --channel conda-forge dysk
+
 # From crates.io
 
 You'll need to have the [Rust development environment](https://www.rustup.rs) installed and up to date.


### PR DESCRIPTION
Resolves #112

* Add install instructions from conda-forge for both Pixi and conda to docs.
   - c.f. https://github.com/conda-forge/dysk-feedstock
* Add conda-forge version badge to README.