### PR TITLE
Add --bar-width option to configure progress bar width

### DIFF
--- a/cli/src/args.rs
+++ b/cli/src/args.rs
@@ -95,6 +95,10 @@ pub struct Args {
     #[arg(long)]
     pub timeout: Option<Timeout>,
 
+    /// width of the progress bar in the 'use' and 'inodes' columns
+    #[arg(long, default_value = "5", value_name = "width")]
+    pub bar_width: usize,
+
     /// if provided, only the device holding this path will be shown
     pub path: Option<std::path::PathBuf>,
 }

--- a/cli/src/table.rs
+++ b/cli/src/table.rs
@@ -25,8 +25,7 @@ static USED_COLOR: u8 = 209;
 static AVAI_COLOR: u8 = 65;
 static SIZE_COLOR: u8 = 172;
 
-static BAR_WIDTH: usize = 5;
-static INODES_BAR_WIDTH: usize = 5;
+
 
 pub fn write<W: Write>(
     w: &mut W,
@@ -75,7 +74,7 @@ pub fn write<W: Write>(
             sub.set("size", units.fmt(stats.size()))
                 .set("used", units.fmt(stats.used()))
                 .set("use-percents", format!("{:.0}%", 100.0 * use_share))
-                .set_md("bar", progress_bar_md(use_share, BAR_WIDTH, args.ascii))
+                .set_md("bar", progress_bar_md(use_share, args.bar_width, args.ascii))
                 .set("free", units.fmt(stats.available()))
                 .set("free-percents", format!("{:.0}%", 100.0 * free_share));
             if let Some(inodes) = &stats.inodes {
@@ -85,7 +84,7 @@ pub fn write<W: Write>(
                     .set("iuse-percents", format!("{:.0}%", 100.0 * iuse_share))
                     .set_md(
                         "ibar",
-                        progress_bar_md(iuse_share, INODES_BAR_WIDTH, args.ascii),
+                        progress_bar_md(iuse_share, args.bar_width, args.ascii),
                     )
                     .set("ifree", inodes.favail);
             }


### PR DESCRIPTION
## Summary
Adds `--bar-width` CLI option to configure the width of progress bars in the `use` and `inodes` columns.
Addresses #114

## Changes
- Added `bar_width` arg to `Args` struct (default: 5)
- Updated `table.rs` to use `args.bar_width` for both bars
- Removed unused `BAR_WIDTH` / `INODES_BAR_WIDTH` constants

## Testing
- `dysk`: default bar width 5
- `dysk --bar-width 20`: wider bar
- `dysk --help`: shows new option

## Note
2 pre-existing test failures in `cols_parsing` (unrelated to this PR).